### PR TITLE
Improve ChatGPTAuthTokenService

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ chatGPTAuthTokenService.refreshToken() : <Promise>
 ```js
 import { ChatGPTAuthTokenService } from "chat-gpt-authenticator";
 
-const chatGPTAuthenticator = new ChatGPTAuthTokenService(
+const chatGptAuthTokenService = new ChatGPTAuthTokenService(
   "OPEN_AI_EMAIL",
   "OPEN_AI_PASSWORD"
 );
 
 (async () => {
-  const token = await chatGPTAuthenticator.getToken();
+  const token = await chatGptAuthTokenService.getToken();
   console.log(token);
 
   token = await chatGPTAuthTokenService.refreshToken();

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,12 @@
 import ChatGPTAuthenticator from "./chat-gpt-authenticator";
 
+const chatGPTAuthenticator = new ChatGPTAuthenticator();
+
 export class ChatGPTAuthTokenService {
   constructor(email, password) {
-    this._email = email;
-    this._password = password;
     this._accessToken = undefined;
+    this.email = email;
+    this.password = password;
   }
 
   async getToken() {
@@ -24,11 +26,10 @@ export class ChatGPTAuthTokenService {
 
   async refreshToken() {
     try {
-      const chatGPTAuthenticator = new ChatGPTAuthenticator(
-        this._email,
-        this._password
+      this._accessToken = await chatGPTAuthenticator.requestToken(
+        this.email,
+        this.password
       );
-      this._accessToken = await chatGPTAuthenticator.requestToken();
       return this._accessToken;
     } catch (e) {
       throw new Error("could not refresh token");


### PR DESCRIPTION
- chatGPTAuthenticator is now a singleton.
- email and password are given to chatGPTAuthenticator.requestToken when needed. 
- email and password are encoded only once, at the beginning of the chain of requests.